### PR TITLE
setStatus fix

### DIFF
--- a/lib/mizuno/rack_servlet.rb
+++ b/lib/mizuno/rack_servlet.rb
@@ -30,7 +30,7 @@ module Mizuno
         # out.
         #
         # Also, we implement a common extension to the Rack api for
-        # asynchronous request processing.  We supply an 'async.callback' 
+        # asynchronous request processing.  We supply an 'async.callback'
         # parameter in env to the Rack application.  If we catch an
         # :async symbol thrown by the app, we initiate a Jetty continuation.
         #
@@ -50,7 +50,7 @@ module Mizuno
             # We should never be re-dispatched.
             raise("Request re-dispatched.") unless continuation.isInitial
 
-            # Add our own special bits to the rack environment so that 
+            # Add our own special bits to the rack environment so that
             # Rack middleware can have access to the Java internals.
             env['rack.java.servlet'] = true
             env['rack.java.servlet.request'] = request
@@ -68,7 +68,7 @@ module Mizuno
             # Execute the Rack request.
             catch(:async) do
                 rack_response = @app.call(env)
-               
+
                 # For apps that don't throw :async.
                 unless(rack_response[0] == -1)
                     # Nope, nothing asynchronous here.
@@ -150,7 +150,7 @@ module Mizuno
         # false otherwise.
         #
         # Note that keep-alive *only* happens if we get either a pathname
-        # (because we can find the length ourselves), or if we get a 
+        # (because we can find the length ourselves), or if we get a
         # Content-Length header as part of the response.  While we can
         # readily buffer the response object to figure out how long it is,
         # we have no guarantee that we aren't going to be buffering
@@ -168,11 +168,11 @@ module Mizuno
                 body.respond_to?(:empty?) and body.empty?)
             return(true) if (finished and response.isCommitted)
 
-            # No need to send headers again if we've already shipped 
+            # No need to send headers again if we've already shipped
             # data out on an async request.
             unless(response.isCommitted)
                 # Set the HTTP status code.
-                response.setStatus(status)
+                response.setStatus(status.to_i)
 
                 # Did we get a Content-Length header?
                 content_length = headers.delete('Content-Length')


### PR DESCRIPTION
Running the latest mizuno code, I ran into this error:

```
org.jruby.exceptions.RaiseException: (NameError) no setStatus with arguments matching [class org.jruby.RubyString] on object #<Java::OrgEclipseJettyServer::Response:0x23493578>
at Mizuno::RackServlet.rack_to_servlet(/Users/pjhyett/.rvm/gems/jruby-1.6.0/gems/mizuno-0.4.0/lib/mizuno/rack_servlet.rb:175)
at Mizuno::RackServlet.service(/Users/pjhyett/.rvm/gems/jruby-1.6.0/gems/mizuno-0.4.0/lib/mizuno/rack_servlet.rb:75)
at org.jruby.RubyKernel.catch(org/jruby/RubyKernel.java:1190)
at Mizuno::RackServlet.service(/Users/pjhyett/.rvm/gems/jruby-1.6.0/gems/mizuno-0.4.0/lib/mizuno/rack_servlet.rb:69)
```

I came across docs[1] saying `setStatus` should take an int instead of string, so I modified the code to run `.to_i` before calling the method. It looks like the proper fix would involve looking at the status first to see whether or not the code should call `setStatus` or `sendError`, but I just wanted to get it into a workable state.

My environment:

```
$ jruby -v
jruby 1.6.0 (ruby 1.8.7 patchlevel 330) (2011-03-15 f3b6154) (Java HotSpot(TM) 64-Bit Server VM 1.6.0_24) [darwin-x86_64-java]
```
1. http://download.oracle.com/javaee/5/api/javax/servlet/http/HttpServletResponse.html#setStatus(int)
