### PR TITLE
Don't set Content-Length in async streaming response in test_app.rb

### DIFF
--- a/spec/test_app.rb
+++ b/spec/test_app.rb
@@ -63,7 +63,7 @@ class TestApp
                     subscriber.call(response.finish)
                     next(true)
                 else
-                    response.write(message)
+                    response.body = message
                     subscriber.call(response.finish)
                     next(false)
                 end


### PR DESCRIPTION
Don't use Rack::Response.write when sending an async response since it will cause Content-Length to be set
