### PR TITLE
change the wait_for_server logic to not use decreasing HTTP timeouts

### DIFF
--- a/lib/mizuno/runner.rb
+++ b/lib/mizuno/runner.rb
@@ -220,11 +220,8 @@ module Mizuno
         #
         def Runner.wait_for_server(options, timeout = 120)
             begin
-                Net::HTTP.start(options[:host], options[:port]) do |http|
-                    http.read_timeout = timeout
-                    response = http.get("/")
-                    return(response.code.to_i < 500)
-                end
+                app_root_uri = URI::HTTP.build(:host => options[:host], :port => options[:port], :path => '/') 
+                return Net::HTTP.get_response(app_root_uri).code.to_i < 500
             rescue Errno::ECONNREFUSED => error
                 return(false) unless ((timeout -= 0.5) > 0)
                 sleep(0.5)


### PR DESCRIPTION
The wait_for_server method currently the the wait-time for the server to start to also function as a Net::HTTP request timeout. This has the odd effect that everytime the you couldn't connect to the server (as it hadn't come up yet), you would error out, and set a smaller timeout upon retry.This seemed odd, as a timeout when connecting to a server should mean that wait a little longer the next time around- not lesser time. 

In addition, since the wait-time for the server to start was already controlled by the decrementing counter in Errno::ECONNREFUSED catch block, it seemed not necessary.
