### PR TITLE
Workaround for bug in JRuby1.7-preview2 that causes Mizuno to crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 archive/
 doc/
 tmp/
+*.iml

--- a/lib/mizuno/rack_servlet.rb
+++ b/lib/mizuno/rack_servlet.rb
@@ -139,7 +139,8 @@ module Mizuno
                 request.getInputStream).to_io.binmode
 
             # Force encoding if we're on Ruby 1.9
-            env['rack.input'].set_encoding(Encoding.find("ASCII-8BIT")) \
+				# Bug in JRuby1.7-p2 doesn't let us use an encoding object
+            env['rack.input'].set_encoding("ASCII-8BIT") \
                 if env['rack.input'].respond_to?(:set_encoding)
 
             # Populate the HTTP headers.


### PR DESCRIPTION
Without this minor change, Mizuno crashes with the following error on every request:

`Rack::Lint::LintError at rack.input #<IO:0xa5e2240> does not have ASCII-8BIT as its external encoding`

You can see what causes it here:
http://jira.codehaus.org/browse/JRUBY-6851
