### PR TITLE
add option to disable log4j default configuration 

### DIFF
--- a/lib/mizuno/choices.rb
+++ b/lib/mizuno/choices.rb
@@ -74,6 +74,13 @@ Choice.options do
         desc 'logfile (defaults to stderr)'
         default nil
     end
+        
+    option :log4j do
+      # e.g. jruby -J-Dlog4j.debug=true -J-Dlog4j.configuration=file:///Users/jilles/git/localstream/backend/src/main/resources/log4j.properties  /Users/jilles/.rbenv/versions/jruby-1.7.2/lib/ruby/gems/shared/gems/mizuno-0.6.6/bin/mizuno --log4j
+      long '--log4j'
+      desc 'Disable default log4j configuration and allow confiuration via -J-Dlog4j.configuration=file://mypath/log4j.properties'
+      default false
+    end
 
     option :rewindable do
         long '--rewindable'

--- a/lib/mizuno/logger.rb
+++ b/lib/mizuno/logger.rb
@@ -24,32 +24,34 @@ module Mizuno
             limit = options[:warn] ? "WARN" : "ERROR"
             limit = "DEBUG" if ($DEBUG or options[:debug])
 
-            # Base logging configuration.
-            config = <<-END
-                log4j.rootCategory = #{limit}, default
-                log4j.logger.org.eclipse.jetty.util.log = #{limit}, default
-                log4j.appender.default.Threshold = #{limit}
-                log4j.appender.default.layout = org.apache.log4j.PatternLayout
-            END
+            if !options[:log4j]
+              # Base logging configuration.
+              config = <<-END
+                  log4j.rootCategory = #{limit}, default
+                  log4j.logger.org.eclipse.jetty.util.log = #{limit}, default
+                  log4j.appender.default.Threshold = #{limit}
+                  log4j.appender.default.layout = org.apache.log4j.PatternLayout
+              END
 
-            # Should we log to the console?
-            config.concat(<<-END) unless options[:log]
-                log4j.appender.default = org.apache.log4j.ConsoleAppender
-                log4j.appender.default.layout.ConversionPattern = %m\\n
-            END
+              # Should we log to the console?
+              config.concat(<<-END) unless options[:log]
+                  log4j.appender.default = org.apache.log4j.ConsoleAppender
+                  log4j.appender.default.layout.ConversionPattern = %m\\n
+              END
 
-            # Are we logging to a file?
-            config.concat(<<-END) if options[:log]
-                log4j.appender.default = org.apache.log4j.FileAppender
-                log4j.appender.default.Append = true
-                log4j.appender.default.File = #{options[:log]}
-                log4j.appender.default.layout.ConversionPattern = %d %p %m\\n
-            END
+              # Are we logging to a file?
+              config.concat(<<-END) if options[:log]
+                  log4j.appender.default = org.apache.log4j.FileAppender
+                  log4j.appender.default.Append = true
+                  log4j.appender.default.File = #{options[:log]}
+                  log4j.appender.default.layout.ConversionPattern = %d %p %m\\n
+              END
 
-            # Set up Log4J via Properties.
-            properties = Properties.new
-            properties.load(ByteArrayInputStream.new(config.to_java_bytes))
-            PropertyConfigurator.configure(properties)
+              # Set up Log4J via Properties.
+              properties = Properties.new
+              properties.load(ByteArrayInputStream.new(config.to_java_bytes))
+              PropertyConfigurator.configure(properties)
+            end
 
             # Create the default logger that gets used everywhere.
             @logger = new


### PR DESCRIPTION
Add option --log4j to disable default log4j configuration to allow confiuration via -J-Dlog4j.configuration=file://mypath/log4j.properties

fix for https://github.com/matadon/mizuno/issues/37
