### PR TITLE
Add option to set SO_REUSEADDR option

### DIFF
--- a/lib/mizuno/server.rb
+++ b/lib/mizuno/server.rb
@@ -78,7 +78,8 @@ module Mizuno
 
             # Connector
             connector = SelectChannelConnector.new
-            connector.setReuseAddress(false)
+            # system may not have SO_REUSEPORT options -> `rescue nil`
+            connector.setReuseAddress(options.fetch(:reuse_address, false)) rescue nil
             connector.setPort(options[:port].to_i)
             connector.setHost(options[:host])
             @server.addConnector(connector)


### PR DESCRIPTION
To make servers' downtime shorter, setting `SO_REUSEPORT` is very important.
This patch make it possible without changing default behavior.
