### PR TITLE
Add max_header_size options parameter with default 32768

### DIFF
--- a/lib/mizuno/server.rb
+++ b/lib/mizuno/server.rb
@@ -82,6 +82,9 @@ module Mizuno
             connector.setReuseAddress(options.fetch(:reuse_address, false)) rescue nil
             connector.setPort(options[:port].to_i)
             connector.setHost(options[:host])
+            max_header_size = options.fetch(:max_header_size, 32768)
+            connector.setRequestHeaderSize(max_header_size)
+            
             @server.addConnector(connector)
 
             # SSL Connector


### PR DESCRIPTION
Using mizuno as a server for some of my APIs I have faced with an issue: sometimes external GET requests have too long URLs, mainly because of too much filters added to query parameters.
Jetty silently responds with "413 FULL head" response.
As I hadn't found a way to configure parameter "RequestHeaderSize" from my application's side I decided to add my changes into mizuno server.rb
Now it works well for me.
I think that HTTP URL size shouldn't be restricted, at least it should have enough capacity for contemporary application: we use HTTP layer not only for browser<->server interaction but also for API<->API. 