### PR TITLE
Replace Thread.exclusive with Mutex and synchronize

### DIFF
--- a/lib/mizuno/reloader.rb
+++ b/lib/mizuno/reloader.rb
@@ -12,6 +12,7 @@ module Mizuno
     # by sending a SIGHUP to the process.
     # 
     class Reloader
+        SEMAPHORE = Mutex.new
         @reloaders = []
 
         @trigger = 'tmp/restart.txt'
@@ -25,7 +26,7 @@ module Mizuno
         end
 
         def Reloader.add(reloader)
-            Thread.exclusive do
+            SEMAPHORE.synchronize do
                 @logger ||= Mizuno::Server.logger
                 @reloaders << reloader
             end
@@ -44,7 +45,7 @@ module Mizuno
         # Reload @app on request.
         #
         def call(env)
-            Thread.exclusive { reload! }
+            SEMAPHORE.synchronize { reload! }
             @app.call(env)
         end
 


### PR DESCRIPTION
This PR avoids a warning and failure on JRuby 9.1.14.0 (2.3.0) by using a Mutex in place of the now-deprecated `Thread.exclusive`.

Tony Arcieri asked Why was this deprecated, and was answered in [this bug thread](https://bugs.ruby-lang.org/issues/11904).
  